### PR TITLE
Allow path and allow 2018 year

### DIFF
--- a/pypums/cli.py
+++ b/pypums/cli.py
@@ -13,10 +13,10 @@ from pypums import pypums
 @click.option(
     "--year",
     required=True,
-    prompt="2000-2017",
-    default=2017,
+    prompt="2000-2018",
+    default=2018,
     show_default=True,
-    type=click.IntRange(min=2000, max=2017, clamp=True),
+    type=click.IntRange(min=2000, max=2018, clamp=True),
 )
 @click.option(
     "--state",

--- a/pypums/download.py
+++ b/pypums/download.py
@@ -1,18 +1,17 @@
 from pathlib import Path
+from typing import Optional
 from tqdm.auto import tqdm
 from zipfile import ZipFile
 import requests
 import time
 
 
-def _check_data_folder(path: str = "../data/raw/", extract: bool = True):
+def _check_data_folder(path: str = "../data/raw/", extract_path: Optional[str] = None):
     path = Path(path)
-
-    if not path.exists():
-        Path("../data/").mkdir()
-        Path("../data/raw/").mkdir()
-        if extract:
-            Path("../data/interim/").mkdir()
+    path.mkdir(parents = True, exist_ok = True)
+    if extract_path is not None:
+        extract_path = Path(extract_path)
+        extract_path.mkdir(parents = True, exist_ok = True)
 
     return None
 
@@ -28,7 +27,7 @@ def download_acs_data(
     """
 
     # Checks download_path and extract_path exists
-    _check_data_folder(path=download_path, extract=extract)
+    _check_data_folder(path=download_path, extract_path=extract_path if extract else None)
 
     # Downloads Data
     BASE_URL = "https://www2.census.gov/programs-surveys/acs/data/pums/"

--- a/pypums/pypums.py
+++ b/pypums/pypums.py
@@ -16,7 +16,7 @@ from pypums.url_builder import build_acs_url
 
 
 def get_data(
-    year: Union[int, str] = "2017",
+    year: Union[int, str] = "2018",
     survey: Union[str, int] = "1-Year",
     person_or_household: str = "person",
     state: str = "California",

--- a/pypums/surveys.py
+++ b/pypums/surveys.py
@@ -26,11 +26,11 @@ def _clean_year(year: Union[int, str]) -> int:
     except ValueError:
         raise ValueError("year must be a number.")
 
-    if (year >= 0) & (year <= 17):
+    if (year >= 0) & (year <= 18):
         year += 2000
 
-    if not (year >= 2000) & (year <= 2017):
-        raise ValueError("Year must be between 2000 and 2017.")
+    if not (year >= 2000) & (year <= 2018):
+        raise ValueError("Year must be between 2000 and 2018.")
     return year
 
 
@@ -106,7 +106,7 @@ def _download_data(
 
 @dataclass
 class ACS:
-    year: Union[int, str] = 2017
+    year: Union[int, str] = 2018
     state: str = "California"
     survey: Union[int, str] = "1-Year"
     person_or_household: str = "person"

--- a/pypums/url_builder.py
+++ b/pypums/url_builder.py
@@ -7,7 +7,7 @@ BASE_URL = "https://www2.census.gov/programs-surveys/"
 
 
 def build_acs_url(
-    year: Union[int, str] = "2017",
+    year: Union[int, str] = "2018",
     survey: Union[str, int] = "1-Year",
     person_or_household: str = "person",
     state: str = "California",


### PR DESCRIPTION
The first commit fixes a `PermissionError: [Errno 13] Permission denied: '../data'` when I tried to run `pypums.get_data(…, download_path="data/raw/", extract_path="data/interim/")`, which was thrown because `_check_data_folder` ignored the `path` parameter. In addition, I use the method [`path.mkdir(parents = True, exists_ok = True)`](https://docs.python.org/3/library/pathlib.html#pathlib.Path.mkdir). `exists_ok` was added in python 3.5, which is ok because [`setup.py`](https://github.com/chekos/pypums/blob/master/setup.py) already has `python_requires=">=3.6"`.

The second commit allows downloading `year = 2018`, which previously failed with `ValueError: Year must be between 2000 and 2017.`